### PR TITLE
Update spec-generator URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - cd math-aria
   - rm -rf common
   - cp -R ../../w3c/math-aria/common .
-  - curl https://labs.w3.org/spec-generator/?type=respec"&"url=https://raw.githack.com/w3c/math-aria/main/index.html -o index.html -f  --retry 3
+  - curl https://www.w3.org/publications/spec-generator/?type=respec"&"url=https://raw.githack.com/w3c/math-aria/main/index.html -o index.html -f  --retry 3
 
 after_success:
   - git add -A .


### PR DESCRIPTION
This updates the spec-generator URL to use the new subdomain/path announced in https://lists.w3.org/Archives/Public/spec-prod/2025OctDec/0008.html.

Note that this URL appears in `.travis.yml`. I am unsure whether this is still actively used for this repository; I got the impression that W3C has largely moved away from Travis CI, and this repo's gh-pages branch has not been pushed to in multiple years. If someone has more information on this repo in particular, let me know if I ought to remove the file entirely instead.